### PR TITLE
Zero to WA and 7 to RA conversions

### DIFF
--- a/scripts/zg12uni51.js
+++ b/scripts/zg12uni51.js
@@ -181,7 +181,7 @@ function Z1_Uni(input)
  
 
 
-   output = output.replace(/(([\u1000-\u101C\u101E-\u102A\u102C\u102E-\u103F\u104C-\u109F\u0020]))(\u1047)/g, function($0, $1)
+   output = output.replace(/(([\u1000-\u101C\u101E-\u102A\u102C\u102E-\u103F\u104C-\u109F]))(\u1047)/g, function($0, $1)
    {
       return $1 ? $1 + '\u101B' : $0 + $1;
 
@@ -189,7 +189,7 @@ function Z1_Uni(input)
    );
    // seven and ra
 
-   output =  output.replace( /(\u1047)( ? = [\u1000 - \u101C\u101E - \u102A\u102C\u102E - \u103F\u104C - \u109F\u0020])/g, "\u101B");
+   output =  output.replace( /(\u1047)( ? = [\u1000 - \u101C\u101E - \u102A\u102C\u102E - \u103F\u104C - \u109F])/g, "\u101B");
    // seven and ra
    
 

--- a/scripts/zg12uni51.js
+++ b/scripts/zg12uni51.js
@@ -174,6 +174,7 @@ function Z1_Uni(input)
 
    }
    );
+   output = output.replace(/([^\u1040-\u1049\u1031])\u1040([\u102b-\u1030\u1036\u1037\u1038\u103a]|[\u1000-\u1021]\u103a)/g, "$1\u101d$2");
    // zero and wa
    
    


### PR DESCRIPTION
<i>Zero to Wa conversion rules is added.</i>
Creteria are -
1. if the preceding character before zero is not any Digit or that preceding character is 0x1031 (E vowel)
2. and zero
3. and following character is one of vowel, tone sign and ASAT or following characters are Consonant + ASAT
that ZERO will change to WA.

<i>7 to RA rule fixed</i>
Removed \u0020 (space character) because of every \u0020\u1047\u0020 (space+myanmar digit seven + space) will not be RA consonant.
 - E.g ၁၀ ဒဿမ ၇ ပေါင် (10 point 7 pounds - 10.7 lbs)